### PR TITLE
fix: use local item-images service by default

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -57,7 +57,7 @@ export const REDIS_CONFIG = {
 };
 
 export const ITEM_IMAGES_SERVICE_CONFIG = {
-  url: getEnv('ITEM_IMAGES_SERVICE_URL') || 'https://item-images.nathanpeck.gg',
+  url: getEnv('ITEM_IMAGES_SERVICE_URL') || 'http://localhost:3001',
 };
 
 export const COGNITO_CONFIG = {


### PR DESCRIPTION
This PR changes the default URL for the item-images service from a hardcoded external URL to a local one
  (http://localhost:3001). This allows developers to run the entire application stack locally without
  relying on an external service.