### PR TITLE
Fix/wrong GitHub repo urls and repo names

### DIFF
--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -9,7 +9,7 @@ version of the service is provided.
 To get started:
 
 ```sh
-git clone git@github.com:kirodotdev/kiro-demo-game.git
+git clone git@github.com:kirodotdev/spirit-of-kiro.git
 ```
 
 ## 2. Setup your environment and install dependencies

--- a/docs/remote-deploy.md
+++ b/docs/remote-deploy.md
@@ -44,8 +44,8 @@ Before deploying the infrastructure, ensure you have:
 ### Clone and Prepare the Repository
 
 ```bash
-git clone git@github.com:kirodotdev/kiro-demo-game.git
-cd kiro-demo-game
+git clone git@github.com:kirodotdev/spirit-of-kiro.git
+cd spirit-of-kiro
 ```
 
 ### Production Deployment


### PR DESCRIPTION
Fix #2 
Issue name - Update remote-deploy.md and local-setup.md with correct  github urls.

remote-deploy.md

Earlier it was - 
`git clone git@github.com:kirodotdev/kiro-demo-game.git`
`cd kiro-demo-game`

Now - 
`git clone git@github.com:kirodotdev/spirit-of-kiro.git`
`cd spirit-of-kiro`


local-setup.md
Earlier it was - 
`git clone git@github.com:kirodotdev/kiro-demo-game.git`

Now - 
`git clone git@github.com:kirodotdev/spirit-of-kiro.git`




Hope it helps in resolving issues related to local setup and remote deploying

