### PR TITLE
change the model name check in scripts/check-dependencies.sh

### DIFF
--- a/scripts/check-dependencies.sh
+++ b/scripts/check-dependencies.sh
@@ -88,7 +88,7 @@ required_models=(
 
 # List of optional models (for image generation)
 optional_models=(
-    "amazon.titan-text-embedding-v2"
+    "amazon.titan-embed-text-v2:0"
     "amazon.nova-canvas"
 )
 


### PR DESCRIPTION
from "amazon.titan-text-embedding-v2" to "amazon.titan-embed-text-v2:0"

*Issue #, if available:*

In `scripts/check-dependencies.sh`, the name of optional embedding model is `amazon.titan-text-embedding-v2`:
<img width="1061" height="706" alt="image" src="https://github.com/user-attachments/assets/a4e61075-f474-4413-b07f-729df0f45468" />

But the real embedding model used in item-images sever is `amazon.titan-embed-text-v2:0`:
<img width="913" height="730" alt="image" src="https://github.com/user-attachments/assets/2f66d541-afdc-497f-9de7-5fd8ed56e4ec" />
I changed the name of the model to be detected from `amazon.titan-text-embedding-v2` to `amazon.titan-embed-text-v2:0`

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
