### PR TITLE
Fix: Match the renamed repo as it is now spirit-of-kiro

### DIFF
--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -9,7 +9,7 @@ version of the service is provided.
 To get started:
 
 ```sh
-git clone git@github.com:kirodotdev/kiro-demo-game.git
+git clone git@github.com:kirodotdev/spirit-of-kiro.git
 ```
 
 ## 2. Setup your environment and install dependencies


### PR DESCRIPTION
I saw this, and did not do an issue first... Sorry.

Update the repo name to the current name of `spirit-of-kiro`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
