### PR TITLE
Change git clone command in local-setup.md to use HTTP instead of SSH.

### DIFF
--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -9,7 +9,7 @@ version of the service is provided.
 To get started:
 
 ```sh
-git clone git@github.com:kirodotdev/spirit-of-kiro.git
+git clone https://github.com/kirodotdev/spirit-of-kiro.git
 ```
 
 ## 2. Setup your environment and install dependencies


### PR DESCRIPTION
*Issue #, if available:*
If a user does not have an SSH key set up with GitHub (e.g. users that do not regularly use GitHub), then using SSH to clone the repo (via `git clone git@github.com:kirodotdev/spirit-of-kiro.git`) is not ideal. (Setting up those SSH keys for the first time is a real pain!  Especially if the user isn't going to use GitHub going forward!)

*Description of changes:*
Change the clone command to ``git clone https://github.com/kirodotdev/spirit-of-kiro.git` in the docs.  (It will also need to be updated on https://kiro.dev/docs/guides/learn-by-playing/00-setup/ , but that's not part of this repo.  Using HTTPS to perform the clone does not require a GitHub login, or any setup at all, beyond already having git installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
